### PR TITLE
clone cfg to make it importable from other files; remove pl dependency on load

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/SuperGluePretrainedNetwork"]
-	path = third_party/SuperGluePretrainedNetwork
-	url = git@github.com:magicleap/SuperGluePretrainedNetwork.git

--- a/configs/loftr/outdoor/loftr_ds.py
+++ b/configs/loftr/outdoor/loftr_ds.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.MATCH_COARSE.MATCH_TYPE = 'dual_softmax'
 
 cfg.TRAINER.CANONICAL_LR = 8e-3

--- a/configs/loftr/outdoor/loftr_ds_dense.py
+++ b/configs/loftr/outdoor/loftr_ds_dense.py
@@ -1,5 +1,6 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
 cfg.LOFTR.MATCH_COARSE.MATCH_TYPE = 'dual_softmax'
 cfg.LOFTR.MATCH_COARSE.SPARSE_SPVS = False
 

--- a/configs/loftr/outdoor/loftr_ds_e2.py
+++ b/configs/loftr/outdoor/loftr_ds_e2.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.BACKBONE_TYPE = 'E2ResNetFPN'
 cfg.LOFTR.RESNETFPN.NBR_ROTATIONS = 4
 

--- a/configs/loftr/outdoor/loftr_ds_e2_dense.py
+++ b/configs/loftr/outdoor/loftr_ds_e2_dense.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.BACKBONE_TYPE = 'E2ResNetFPN'
 cfg.LOFTR.RESNETFPN.NBR_ROTATIONS = 4
 

--- a/configs/loftr/outdoor/loftr_ds_e2_dense_8rot.py
+++ b/configs/loftr/outdoor/loftr_ds_e2_dense_8rot.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.BACKBONE_TYPE = 'E2ResNetFPN'
 cfg.LOFTR.RESNETFPN.NBR_ROTATIONS = 8
 

--- a/configs/loftr/outdoor/loftr_ds_e2_dense_big.py
+++ b/configs/loftr/outdoor/loftr_ds_e2_dense_big.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.BACKBONE_TYPE = 'E2ResNetFPN'
 cfg.LOFTR.RESNETFPN.NBR_ROTATIONS = 4
 cfg.LOFTR.RESNETFPN.E2_SAME_NBR_FILTERS = False

--- a/configs/loftr/outdoor/loftr_ot.py
+++ b/configs/loftr/outdoor/loftr_ot.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.MATCH_COARSE.MATCH_TYPE = 'sinkhorn'
 
 cfg.TRAINER.CANONICAL_LR = 8e-3

--- a/configs/loftr/outdoor/loftr_ot_dense.py
+++ b/configs/loftr/outdoor/loftr_ot_dense.py
@@ -1,5 +1,7 @@
 from src.config.default import _CN as cfg
 
+cfg = cfg.clone()
+
 cfg.LOFTR.MATCH_COARSE.MATCH_TYPE = 'sinkhorn'
 cfg.LOFTR.MATCH_COARSE.SPARSE_SPVS = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ ipython
 jupyterlab
 matplotlib
 h5py==3.1.0
-pytorch-lightning==1.3.5
+# pytorch-lightning==1.3.5
 joblib>=1.0.1

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -7,7 +7,10 @@ from itertools import chain
 
 import torch
 from yacs.config import CfgNode as CN
-from pytorch_lightning.utilities import rank_zero_only
+try:
+    from pytorch_lightning.utilities import rank_zero_only
+except ModuleNotFoundError:
+    print('WARNING: No pytorch lightning installed. This is ok for interence. Please install pytorch lightning if you want to train.')
 
 
 def lower_config(yacs_cfg):


### PR DESCRIPTION
Hi Georg, 

I'm trying to integrate this work into https://github.com/gmberton/image-matching-models (IMM) and found a few hiccups. 

1) importing the cfg doesnt take up the changes from within the file unless the cfg is cloned at the top
2) pytorch lightning is required to load due to its one function call inside utils/misc.py and that the model checkpoints are saved as lightning checkpoints. Fix for the former is in this PR, for the latter I saved out only the state dict (removing the optimizer, etc from the .ckpt file you share) and saved that out at https://drive.google.com/drive/folders/1VDYMw-vZ9aE_0cNOPNEz08DeLfQPapKO

If these look ok to you then we could add this to IMM. Thanks and thanks for all your great work on this project. 